### PR TITLE
Fixed a bug in QuerySelectMultipleField.iter_choices()

### DIFF
--- a/wtforms/ext/sqlalchemy/fields.py
+++ b/wtforms/ext/sqlalchemy/fields.py
@@ -170,7 +170,7 @@ class QuerySelectMultipleField(QuerySelectField):
 
     def iter_choices(self):
         for pk, obj in self._get_object_list():
-            yield (pk, self.get_label(obj), obj in self.data)
+            yield (pk, self.get_label(obj), obj in (self.data or []))
 
     def process_formdata(self, valuelist):
         self._formdata = set(valuelist)


### PR DESCRIPTION
When`self.data` is `None`, `obj in self.data` raises a `TypeError: argument of type 'NoneType' is not iterable` error.
Fixes #115
